### PR TITLE
Cell fmt parade

### DIFF
--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -173,7 +173,11 @@ impl fmt::Display for Cell {
                     .map(|b| format!("{:02X}", b))
                     .collect::<Vec<String>>()
                     .join("");
-                write!(f, r#"\x{}"#, hex)
+                if hex.is_empty() {
+                    write!(f, "''")
+                } else {
+                    write!(f, r#"'\x{}'"#, hex)
+                }
             }
             Cell::Uuid(v) => {
                 write!(f, "'{}'", v)

--- a/supabase-wrappers/src/interface.rs
+++ b/supabase-wrappers/src/interface.rs
@@ -354,7 +354,7 @@ impl FromDatum for Cell {
 }
 
 pub trait CellFormatter {
-    fn fmt_cell(&self, cell: &Cell) -> String;
+    fn fmt_cell(&mut self, cell: &Cell) -> String;
 }
 
 struct DefaultFormatter {}
@@ -366,7 +366,7 @@ impl DefaultFormatter {
 }
 
 impl CellFormatter for DefaultFormatter {
-    fn fmt_cell(&self, cell: &Cell) -> String {
+    fn fmt_cell(&mut self, cell: &Cell) -> String {
         format!("{}", cell)
     }
 }
@@ -509,11 +509,11 @@ pub struct Qual {
 
 impl Qual {
     pub fn deparse(&self) -> String {
-        let formatter = DefaultFormatter::new();
-        self.deparse_with_fmt(formatter)
+        let mut formatter = DefaultFormatter::new();
+        self.deparse_with_fmt(&mut formatter)
     }
 
-    pub fn deparse_with_fmt<T: CellFormatter>(&self, t: T) -> String {
+    pub fn deparse_with_fmt<T: CellFormatter>(&self, t: &mut T) -> String {
         if self.use_or {
             match &self.value {
                 Value::Cell(_) => unreachable!(),
@@ -534,11 +534,11 @@ impl Qual {
                         Cell::String(cell) if cell == "null" => {
                             format!("{} {} null", self.field, self.operator)
                         }
-                        _ => format!("{} {} {}", self.field, self.operator, cell),
+                        _ => format!("{} {} {}", self.field, self.operator, t.fmt_cell(cell)),
                     },
-                    "~~" => format!("{} like {}", self.field, cell),
-                    "!~~" => format!("{} not like {}", self.field, cell),
-                    _ => format!("{} {} {}", self.field, self.operator, cell),
+                    "~~" => format!("{} like {}", self.field, t.fmt_cell(cell)),
+                    "!~~" => format!("{} not like {}", self.field, t.fmt_cell(cell)),
+                    _ => format!("{} {} {}", self.field, self.operator, t.fmt_cell(cell)),
                 },
                 Value::Array(_) => unreachable!(),
             }


### PR DESCRIPTION
This pr:
1. Fix bug in Cell type Bytea fmt function.  
   1.1 Missing single quotes around the string \xABCD -> '\xABCD' (...)
   1.2 if bytes len is 0, it should be '' . '\x' -> ''.
2. I found a bug before. It's because the different representation of hex in postgres and duckdb.
duckdb hex: '\xAB\xCD'
postgres hex: '\xABCD'
It's not compatible. So ...I think it should implement postgres style in Wrapper repo. Duckdb style should be a user-defined function. And I implement `trait CellFormatter ` allow to do that.
This implementation is better than implementing the DuckDB pattern and more conducive to upstream. 
raise a PR : https://github.com/supabase/wrappers/pull/316 